### PR TITLE
Add the ability to specify additional connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ CardConnect.configure do |config|
 end
 ```
 
+You may pass additional options into the [Faraday connection](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb) via `connection_options`.
+
+```ruby
+CardConnection.configure do |config|
+  config.connection_options = { ssl: your_ssl_options }
+end
+```
+
+_Note: We do not recommend setting `verify: false`_
+
 ## Services
 
 ### Authorization Service

--- a/lib/cardconnect/configuration.rb
+++ b/lib/cardconnect/configuration.rb
@@ -5,6 +5,7 @@ module CardConnect
     attr_accessor :api_username
     attr_accessor :api_password
     attr_accessor :endpoint
+    attr_accessor :connection_options
 
     def initialize
     end

--- a/lib/cardconnect/configuration.rb
+++ b/lib/cardconnect/configuration.rb
@@ -8,6 +8,7 @@ module CardConnect
     attr_accessor :connection_options
 
     def initialize
+      @connection_options = {}
     end
   end
 end

--- a/lib/cardconnect/connection.rb
+++ b/lib/cardconnect/connection.rb
@@ -33,7 +33,7 @@ module CardConnect
         headers: {
           user_agent: "CardConnectRubyGem/#{CardConnect::VERSION}"
         },
-      }.merge(@config.connection_options.to_h)
+      }.merge(@config.connection_options)
     end
   end
 end

--- a/lib/cardconnect/connection.rb
+++ b/lib/cardconnect/connection.rb
@@ -3,13 +3,12 @@ require 'faraday_middleware'
 
 module CardConnect
   class Connection
-    def initialize
-      @config = CardConnect.configuration
-      @headers = { user_agent: "CardConnectRubyGem/#{CardConnect::VERSION}" }
+    def initialize(config = CardConnect.configuration)
+      @config = config
     end
 
     def connection
-      @connection ||= Faraday.new(url: @config.endpoint, headers: @headers, ssl: { verify: false }) do |f|
+      @connection ||= Faraday.new(faraday_options) do |f|
         f.request :basic_auth, @config.api_username, @config.api_password
         f.request :json
 
@@ -26,6 +25,15 @@ module CardConnect
       return e
     rescue Faraday::ClientError => e
       return e
+    end
+
+    def faraday_options
+      {
+        url: @config.endpoint,
+        headers: {
+          user_agent: "CardConnectRubyGem/#{CardConnect::VERSION}"
+        },
+      }.merge(@config.connection_options.to_h)
     end
   end
 end

--- a/test/cardconnect/configuration_test.rb
+++ b/test/cardconnect/configuration_test.rb
@@ -24,4 +24,8 @@ describe CardConnect::Configuration do
   it 'must respond to endpoint' do
     @config.must_respond_to :endpoint
   end
+
+  it 'must respond to connection_options' do
+    @config.must_respond_to :connection_options
+  end
 end

--- a/test/cardconnect/connection_test.rb
+++ b/test/cardconnect/connection_test.rb
@@ -31,6 +31,17 @@ describe CardConnect::Connection do
       it 'must have a handler for parsing the json response third' do
         @connection.builder.handlers[2].must_be :===, FaradayMiddleware::ParseJson
       end
+
+      it 'has ssl verification on by default' do
+        assert(@connection.ssl.verify?)
+      end
+
+      it 'has the ability to accept ssl options' do
+        config = CardConnect.configuration.dup
+        config.connection_options = { ssl: { verify: false } }
+        connection = CardConnect::Connection.new(config).connection
+        refute(connection.ssl.verify)
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ end
 module CardConnect
   class Connection
     def connection
-      @connection ||= Faraday.new(url: @config.endpoint, headers: @headers) do |faraday|
+      @connection ||= Faraday.new(faraday_options) do |faraday|
         faraday.request :basic_auth, @config.api_username, @config.api_password
         faraday.request :json
 


### PR DESCRIPTION
For example, if you need to specify `ssl: { verify: false }` in order to get
around a cerificate problem (which I don't recommend, but might be a stopgap),
you may specify when configuring:

```ruby
config.connection_options = { ssl: { verify: false } }
```

This will accept any of faraday's options. See https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb

I didn't see a changelog, so I wasn't sure how you wanted to handle what might be a breaking change for some people. In theory, it shouldn't break anything--and should just make everyone a little more secure--because the certificates _should_ be valid, but there's a chance there's some certificate out there that isn't.

Also, I looked but didn't see any examples of your preferred hash syntax, so if it needs to support older `=>`, that's an easy change. And I'm not fluent in minitest (I spend most of my life in rspec), so if there's a preferred idiom, I'm happy to change it.

Addresses Issue #3.