### PR TITLE
Removed duplicate fields in Inquire response

### DIFF
--- a/lib/cardconnect/services/inquire/inquire_response.rb
+++ b/lib/cardconnect/services/inquire/inquire_response.rb
@@ -6,7 +6,7 @@ module CardConnect
       FIELDS = [
         :merchid, :account, :amount, :currency, :retref, :respcode,
         :respproc, :respstat, :resptext, :setlstat, :capturedate, :batchid,
-        :token, :authdate, :lastfour, :name, :currency, :settledate
+        :token, :authdate, :lastfour, :name, :settledate
       ].freeze
 
       # Settlement Status

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ end
 # Stub out the Faraday connection for testing.
 module CardConnect
   class Connection
+    undef :connection if method_defined? :connection
+
     def connection
       @connection ||= Faraday.new(faraday_options) do |faraday|
         faraday.request :basic_auth, @config.api_username, @config.api_password


### PR DESCRIPTION
1. Removed duplicate field 'currency' defined in InquireResponse
2. Fixed the following  warning
    a. warning: method redefined; discarding old connection (test_helper.rb:21)
    b. warning: previous definition of connection was here ( connection.rb:10)
