### PR TITLE
Made rest method mandatory in Profile constructor

### DIFF
--- a/lib/cardconnect/services/profile/profile.rb
+++ b/lib/cardconnect/services/profile/profile.rb
@@ -5,7 +5,7 @@ module CardConnect
       #
       # @param connection [CardConnect::Connection]
       # @return CardConnect::Service::Profile
-      def initialize(rest_method = nil, connection = CardConnect.connection)
+      def initialize(rest_method, connection = CardConnect.connection)
         super(connection)
         @resource_name = '/profile'
         @rest_method = rest_method


### PR DESCRIPTION
In CardConnect::Service::Profile constructor, the 'rest' method is allowed to accept 'nil' as default parameter.

It is throwing error when the Profile class is created without argument.
I suggest it is good to accept 'rest' argument value from user. 
