### PR TITLE
Option to utilize run-time credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ response = service.submit
 
 http://developer.cardconnect.com/cardconnect-api/#response-codes
 
+## Run-time logins
+Typically, you want to use `config/initializers/cardconnect.rb` to set your API username and password details in a secure way, as detailed above. If you need to connect to multiple CardConnect accounts, you can specify the username/password immediately before processing a transaction.
+
+Example:
+```
+config = CardConnect::Configuration.new
+config.api_username = "username"
+config.api_password = "password123"
+config.endpoint = "https://url.com"
+
+connection = CardConnect::Connection.new(config).connection
+service = CardConnect::Service::Authorize.new(connection)
+service.build_request(params)
+response = service.submit
+```
+Username, password, and/or endpoint can be defined either in the CardConnect initializer or overridden at runtime.
+
 ## To Do:
 
 #### Authorization Service

--- a/lib/cardconnect/connection.rb
+++ b/lib/cardconnect/connection.rb
@@ -7,9 +7,10 @@ module CardConnect
       @config = config
     end
 
-    def connection
+    def connection(config = nil)
+      config ||= @config
       @connection ||= Faraday.new(faraday_options) do |f|
-        f.request :basic_auth, @config.api_username, @config.api_password
+        f.request :basic_auth, config.api_username, config.api_password
         f.request :json
 
         f.response :json, content_type: /\bjson$/


### PR DESCRIPTION
I have a requirement of connecting to multiple CardConnect accounts, depending on business logic.  Using the hint @jjoshuadelange and @prashm provided in [Issue #4](https://github.com/mobilecause/cardconnect/issues/14), I've added the capability to provide API username/password/url when making the initial connection.

It should be fully backwards compatible, allowing users to use the initializer-provided API credentials or specifying them at run-time.  

I thought this might help someone else down the road.  

I attempted to add some specs, but honestly couldn't figure out how to check Faraday for the basic auth parameters (user/pw).  If anyone has a suggestion, I'm happy to add a few specs as well.